### PR TITLE
Deamer External V1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-project(Deamer_External VERSION 1.0
+project(Deamer_External VERSION 1.1
                   DESCRIPTION "Deamer CC output dependencies."
                   LANGUAGES CXX)
 
@@ -20,7 +20,7 @@ if(NOT DEFINED Deamer_External_VERSION_MAJOR)
   set(Deamer_External_VERSION_MAJOR 1)
 endif()
 if(NOT DEFINED Deamer_External_VERSION_MINOR)
-  set(Deamer_External_VERSION_MINOR 0)
+  set(Deamer_External_VERSION_MINOR 1)
 endif()
 if(NOT DEFINED Deamer_External_VERSION_PATCH)
   set(Deamer_External_VERSION_PATCH 0)

--- a/include/Deamer/External/Cpp/Ast/Node.h
+++ b/include/Deamer/External/Cpp/Ast/Node.h
@@ -223,6 +223,11 @@ namespace deamer::external::cpp::ast
 			return foundNodes;
 		}
 		
+		
+		/*!	\fn Get
+		 *	
+		 *	\see GetIndex
+		 */
 		const Node* Get(size_t index) const
 		{
 			if (index >= nodes.size())
@@ -233,8 +238,29 @@ namespace deamer::external::cpp::ast
 			return nodes[index];
 		}
 		
+		const Node* GetIndex(size_t index) const
+		{
+			return Get(index);
+		}
+		
+		const Node* GetIndex(int index) const
+		{
+			if (index >= nodes.size() || index < 0)
+			{
+				throw std::logic_error("There is no child at the specified index!");
+			}
+
+			return nodes[index];
+		}
+		
 		template<typename T>
 		const Node* Get(T t, size_t index) const
+		{
+			return Get(t)[index];
+		}
+		
+		template<typename T>
+		const Node* Get(T t, int index) const
 		{
 			return Get(t)[index];
 		}
@@ -327,9 +353,24 @@ namespace deamer::external::cpp::ast
 			return child->GetValue();
 		}
 		
+		/*!	\fn GetChildValue
+		 *	
+		 *	\see GetChildValueAtIndex
+		 */
 		std::string GetChildValue(size_t index = 0) const
 		{
-			const auto* const child = Get(index);
+			const auto* const child = GetIndex(index);
+			return child->GetValue();
+		}
+		
+		std::string GetChildValueAtIndex(size_t index = 0) const
+		{
+			return GetChildValue(index);
+		}
+		
+		std::string GetChildValueAtIndex(int index = 0) const
+		{
+			const auto* const child = GetIndex(index);
 			return child->GetValue();
 		}
 

--- a/include/Deamer/External/Cpp/Parser/Constant/TreeType.h
+++ b/include/Deamer/External/Cpp/Parser/Constant/TreeType.h
@@ -1,0 +1,19 @@
+#ifndef DEAMER_EXTERNAL_PARSER_CONSTANT_TREETYPE_H
+#define DEAMER_EXTERNAL_PARSER_CONSTANT_TREETYPE_H
+
+namespace deamer::external::cpp::parser
+{
+	/*!	\enum TreeType
+	 *
+	 *	\brief Specifies which tree is used.
+	 *
+	 *	\details One can modify parser output by specifying what tree is desired.
+	 */
+	enum class TreeType
+	{
+		ast,
+		cst,
+	};
+}
+
+#endif // DEAMER_EXTERNAL_PARSER_CONSTANT_TREETYPE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(INSTALL_GTEST off)
 add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest")
 
 mark_as_advanced(


### PR DESCRIPTION
This update offers a few new additions which improve the usage of AST Nodes:
- GetText function for ast nodes.
- Introduction of GetIndex and GetChildValueAtIndex, both have overloads for int.
- Deprecate the functions:
    - Get(int)
    - GetChildValue(int)
    These functions are used with enumeration logic, not as indexes. This results in conflicting results. Use the "Index" alternatives to access by index.